### PR TITLE
Add an optional API version to Stripe config

### DIFF
--- a/src/main/scala/com/gu/support/config/StripeConfig.scala
+++ b/src/main/scala/com/gu/support/config/StripeConfig.scala
@@ -1,12 +1,20 @@
 package com.gu.support.config
 
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigException}
 
-case class StripeConfig(secretKey: String, publicKey: String) extends TouchpointConfig
+import scala.util.control.Exception.catching
 
-class StripeConfigProvider(config: Config, defaultStage: Stage, prefix: String = "stripe") extends TouchpointConfigProvider[StripeConfig](config, defaultStage) {
+case class StripeConfig(secretKey: String, publicKey: String, version: Option[String]) extends TouchpointConfig
+
+class StripeConfigProvider(config: Config, defaultStage: Stage, prefix: String = "stripe", version: Option[String] = None) extends TouchpointConfigProvider[StripeConfig](config, defaultStage) {
   def fromConfig(config: Config): StripeConfig = StripeConfig(
     secretKey = config.getString(s"$prefix.api.key.secret"),
-    publicKey = config.getString(s"$prefix.api.key.public")
+    publicKey = config.getString(s"$prefix.api.key.public"),
+    version = stripeVersion(config)
   )
+
+  def stripeVersion(config: Config): Option[String] = {
+    val catchMissing = catching(classOf[ConfigException.Missing])
+    catchMissing opt config.getString(s"stripe.api.version")
+  }
 }

--- a/src/main/scala/com/gu/support/config/StripeConfig.scala
+++ b/src/main/scala/com/gu/support/config/StripeConfig.scala
@@ -1,8 +1,6 @@
 package com.gu.support.config
 
-import com.typesafe.config.{Config, ConfigException}
-
-import scala.util.control.Exception.catching
+import com.typesafe.config.Config
 
 case class StripeConfig(secretKey: String, publicKey: String, version: Option[String]) extends TouchpointConfig
 
@@ -14,7 +12,7 @@ class StripeConfigProvider(config: Config, defaultStage: Stage, prefix: String =
   )
 
   def stripeVersion(config: Config): Option[String] = {
-    val catchMissing = catching(classOf[ConfigException.Missing])
-    catchMissing opt config.getString(s"stripe.api.version")
+    val stripeVersion = "stripe.api.version"
+    if (config.hasPath(stripeVersion)) Some(config.getString(stripeVersion)) else None
   }
 }


### PR DESCRIPTION
When updating the version of the Stripe API we are using, it would be useful to be able to try out a newer version app by app before updating the version globally in the Stripe dashboard.

I am adding an optional Stripe API version to the stripe config so that I can send the version header if configured where we are making calls to Stripe (i.e. from within support-workers).

cc @rupertbates @paulbrown1982 @johnduffell @davidfurey 